### PR TITLE
Danktronics Media v2

### DIFF
--- a/docs/media/Overview.md
+++ b/docs/media/Overview.md
@@ -29,8 +29,8 @@ Media can expose multiple versions of the API (often for testing or deprecation 
 
 | Version | Status       | Stable  |
 | ------- | ------------ | ------- |
-| 1       | Available    | ✔️      |
-| 2       | Testing      |         |
+| 1       | Discontinued | ✔️      |
+| 2       | Available    | ✔️      |
 
 ## Nullable and Optional Resource Keys
 

--- a/docs/media/Overview.md
+++ b/docs/media/Overview.md
@@ -22,18 +22,15 @@ The `Authorization` header must always be present and contain an API token.
 
 An API token can currently be retrieved by going to settings on the website and revealing the token.
 
-## Processing Responses
+## Versioning
+Media can expose multiple versions of the API (often for testing or deprecation purposes). In order to specify the version of the API you would like to use, you must prefix the route with `/api/v{version_number}/`. If you don't include a version in the URL then the API will automatically default to the latest current stable version. The following table documents the current state of API versions.
 
-Currently all responses follow the same data structure
+###### API Versions
 
-> :warning: **This structure is going to be removed in a future version**
-
-###### Response Structure
-
-| Key                           | Type                                                                                | Description                                                                                                                      |
-| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| code                          | integer                                                                             | HTTP response code                                                                                                               |
-| data                          | object                                                                              | relevant data                                                                                                                    |
+| Version | Status       | Stable  |
+| ------- | ------------ | ------- |
+| 1       | Available    | ✔️      |
+| 2       | Testing      |         |
 
 ## Nullable and Optional Resource Keys
 

--- a/docs/media/important/Change_Log.md
+++ b/docs/media/important/Change_Log.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## Removal of uniform data structure and ISO creation times
+
+### TBD
+
+The data structure that was returned by all API endpoints will no longer be present in favor of only returning the data. This was a bloated feature of the API. Also all objects returned by the API will no longer contain ISO-8601 `created_at` fields in favor of parsing the snowflake ID for a instantaneous timestamp.

--- a/docs/media/important/Change_Log.md
+++ b/docs/media/important/Change_Log.md
@@ -4,4 +4,4 @@
 
 ### TBD
 
-The data structure that was returned by all API endpoints will no longer be present in favor of only returning the data. This was a bloated feature of the API. Also all objects returned by the API will no longer contain ISO-8601 `created_at` fields in favor of parsing the snowflake ID for a instantaneous timestamp.
+The data structure that was returned by all API endpoints will no longer be present in favor of only returning the data. This was a bloated feature of the API. Also all objects returned by the API will no longer contain ISO-8601 `created_at` fields in favor of parsing the snowflake ID for an instantaneous timestamp.

--- a/docs/media/important/Change_Log.md
+++ b/docs/media/important/Change_Log.md
@@ -4,4 +4,7 @@
 
 ### TBD
 
-The data structure that was returned by all API endpoints will no longer be present in favor of only returning the data. This was a bloated feature of the API. Also all objects returned by the API will no longer contain ISO-8601 `created_at` fields in favor of parsing the snowflake ID for an instantaneous timestamp.
+* The data structure that was returned by all API endpoints will no longer be present in favor of only returning the data.
+* All objects returned by the API will no longer contain ISO-8601 `created_at` fields in favor of parsing the snowflake ID for an instantaneous timestamp.
+* `quickURL` (in QuickLinks) has been renamed to `quick_url` to conform with the rest of the API.
+* `url` (in QuickLinks) has been renamed to `redirect_url` for clarity.

--- a/docs/media/resources/Image.md
+++ b/docs/media/resources/Image.md
@@ -13,7 +13,6 @@ This documents all functionality related to images.
 | extension                     | string                                                                              | image extension                                                                                                                  |
 | url                           | string                                                                              | ease of use url for accessing the image                                                                                          |
 | owner                         | snowflake                                                                           | id of the uploader/owner                                                                                                         |
-| created_at                    | ISO8601 timestamp                                                                   | when the image was uploaded                                                                                                      |
 
 ## Upload Image - POST /images
 

--- a/docs/media/resources/Image.md
+++ b/docs/media/resources/Image.md
@@ -12,7 +12,7 @@ This documents all functionality related to images.
 | hash                          | string                                                                              | image hash (specifically for viewing)                                                                                            |
 | extension                     | string                                                                              | image extension                                                                                                                  |
 | url                           | string                                                                              | ease of use url for accessing the image                                                                                          |
-| owner                         | snowflake                                                                           | id of the uploader/owner                                                                                                         |
+| owner_id                      | snowflake                                                                           | id of the uploader/owner                                                                                                         |
 
 ## Upload Image - POST /images
 

--- a/docs/media/resources/Post.md
+++ b/docs/media/resources/Post.md
@@ -11,7 +11,7 @@ This documents all functionality related to posts.
 | id                            | snowflake                                                                           | post identifier                                                                                                                  |
 | title                         | string                                                                              | title of the post                                                                                                                |
 | message                       | string                                                                              | post content                                                                                                                     |
-| creator                       | snowflake                                                                           | id of the poster                                                                                                                 |
+| creator_id                    | snowflake                                                                           | id of the poster                                                                                                                 |
 
 ## Get Posts - GET /posts
 

--- a/docs/media/resources/Post.md
+++ b/docs/media/resources/Post.md
@@ -12,7 +12,6 @@ This documents all functionality related to posts.
 | title                         | string                                                                              | title of the post                                                                                                                |
 | message                       | string                                                                              | post content                                                                                                                     |
 | creator                       | snowflake                                                                           | id of the poster                                                                                                                 |
-| created_at                    | ISO8601 timestamp                                                                   | when the post was created                                                                                                        |
 
 ## Get Posts - GET /posts
 

--- a/docs/media/resources/QuickLinks.md
+++ b/docs/media/resources/QuickLinks.md
@@ -1,0 +1,23 @@
+# QuickLink Resources
+
+This documents all functionality related to quick links.
+
+### QuickLink Object
+
+###### QuickLink Structure
+
+| Key                           | Type                                                                                | Description                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| id                            | snowflake                                                                           | quick link identifier                                                                                                            |
+| owner_id                      | snowflake                                                                           | quick link owner's id                                                                                                            |
+| hash                          | string                                                                              | hash of the quick link                                                                                                           |
+| quick_url                     | string                                                                              | ease of use url for redirecting using media                                                                                      |
+| redirect_url                  | string                                                                              | url quick link is pointing to                                                                                                    |
+
+## Get QuickLink - GET /quicklinks
+
+Returns an array of the current user's quick links
+
+## Create QuickLink - POST /quicklinks
+
+Provide an object with key url to redirect to. Returns the new quick link object

--- a/docs/media/resources/User.md
+++ b/docs/media/resources/User.md
@@ -11,7 +11,6 @@ This documents all functionality related to users.
 | id                            | snowflake                                                                           | user identifier                                                                                                                  |
 | username                      | string                                                                              | user's username                                                                                                                    |
 | avatar                        | ?string                                                                             | avatar hash and extension                                                                                                        |
-| created_at                    | ISO8601 timestamp                                                                   | when the user was created                                                                                                        |
 | admin                         | boolean                                                                             | whether this user is an administrator                                                                                            |
 
 ## Get User - GET /users/{id}


### PR DESCRIPTION
Our second Media major API version has been created to fix the mistakes of version 1. This includes removing verbosity (data structure and `created_at`) and fixing hash generation. Instead of using `created_at`, retrieve creation time from the ID (which is a snowflake) by bit shifting 22 bits to the right.

**The deprecation period starts now and will last for 1 week. V1 will no longer work after the deprecation period.**

This closes #1, closes #2, and closes #3.