### PR TITLE
Media V3

### DIFF
--- a/docs/media/Overview.md
+++ b/docs/media/Overview.md
@@ -31,6 +31,7 @@ Media can expose multiple versions of the API (often for testing or deprecation 
 | ------- | ------------ | ------- |
 | 1       | Discontinued |         |
 | 2       | Available    | ✔️      |
+| 3       | Private      |         |
 
 ## Nullable and Optional Resource Keys
 

--- a/docs/media/Overview.md
+++ b/docs/media/Overview.md
@@ -31,7 +31,7 @@ Media can expose multiple versions of the API (often for testing or deprecation 
 | ------- | ------------ | ------- |
 | 1       | Discontinued |         |
 | 2       | Available    | ✔️      |
-| 3       | Private      |         |
+| 3       | Available    | ✔️      |
 
 ## Nullable and Optional Resource Keys
 

--- a/docs/media/important/Change_Log.md
+++ b/docs/media/important/Change_Log.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Limiting Data Retrieval
+
+### TBD
+
+* Now by default the Images and QuickLinks GET endpoint will return 10 items
+* Images and QuickLinks GET endpoint can be customized with before, after, and limit (to retrieve more data)
+* Images and QuickLinks GET endpoint return the total number of items owned by the current user (as this would be taxing to calculate with multiple requests)
+
 ## Removal of uniform data structure and ISO creation times
 
 ### 5/21/2020

--- a/docs/media/important/Change_Log.md
+++ b/docs/media/important/Change_Log.md
@@ -2,7 +2,7 @@
 
 ## Limiting Data Retrieval
 
-### TBD
+### 7/24/2020
 
 * Now by default the Images and QuickLinks GET endpoint will return 10 items
 * Images and QuickLinks GET endpoint can be customized with before, after, and limit (to retrieve more data)

--- a/docs/media/resources/Image.md
+++ b/docs/media/resources/Image.md
@@ -14,13 +14,26 @@ This documents all functionality related to images.
 | url                           | string                                                                              | ease of use url for accessing the image                                                                                          |
 | owner_id                      | snowflake                                                                           | id of the uploader/owner                                                                                                         |
 
+## Get Images - GET /images
+
+Returns an array of uploaded image objects that the current user uploaded.
+
+Query String Parameters
+| Key                           | Type                                                                                | Description                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| before                        | snowflake                                                                           | get images before this ID                                                                                                        |
+| after                         | snowflake                                                                           | get images after this ID                                                                                                         |
+| limit                         | integer                                                                             | amount of images to return (default of 10)                                                                                       |
+
+Response
+| Key                           | Type                                                                                | Description                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| total_count                   | integer                                                                             | amount of owned images                                                                                                           |
+| images                        | array of Image objects                                                              | array of owned images                                                                                                            |
+
 ## Upload Image - POST /images
 
 Upload an image.
 
 This endpoint only supports requests with a `Content-Type` of `multipart/form-data`. You must send a PNG/JPG/GIF with the correct type
 and the file form name must be `file`.
-
-## Get Images - GET /images
-
-Returns an array of uploaded image objects that the current user uploaded.

--- a/docs/media/resources/QuickLinks.md
+++ b/docs/media/resources/QuickLinks.md
@@ -16,7 +16,20 @@ This documents all functionality related to quick links.
 
 ## Get QuickLink - GET /quicklinks
 
-Returns an array of the current user's quick links
+Returns some of the current user's quick links
+
+Query String Parameters
+| Key                           | Type                                                                                | Description                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| before                        | snowflake                                                                           | get quick links before this ID                                                                                                   |
+| after                         | snowflake                                                                           | get quick links after this ID                                                                                                    |
+| limit                         | integer                                                                             | amount of quick links to return (default of 10)                                                                                  |
+
+Response
+| Key                           | Type                                                                                | Description                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| total_count                   | integer                                                                             | amount of owned quick links                                                                                                      |
+| quick_links                   | array of QuickLink objects                                                          | array of owned quick links                                                                                                       |
 
 ## Create QuickLink - POST /quicklinks
 


### PR DESCRIPTION
Our third Media major API version has been created to improve user experience and server stress. This includes the pagination of images and quick links (instead of returning massive arrays) and `total_count` in responses. This means you can specify what data you want without having to process everything!

**The deprecation period starts now and will last for 1 day. V2 will no longer work after the deprecation period.**